### PR TITLE
auto ==> decltype(auto)

### DIFF
--- a/index.html
+++ b/index.html
@@ -752,7 +752,7 @@ void f( T x ) ;
 例えば、
 </p>
 
-<pre><code>auto x = expr ;
+<pre><code>decltype(auto) x = expr ;
 </code></pre>
 
 <p>


### PR DESCRIPTION
×例えば、auto x = expr ; という宣言は、以下のように書いたものと同じになる。decltype(expr) x = expr ;
○例えば、decltype(auto) x = expr ; という宣言は、以下のように書いたものと同じになる。decltype(expr) x = expr ;
